### PR TITLE
Update handbook_02_contractual_statement.tex

### DIFF
--- a/handbook_02_contractual_statement.tex
+++ b/handbook_02_contractual_statement.tex
@@ -1006,7 +1006,7 @@
 					\item{
 						\label{par:ReviewOfDecisionNotToIssueANoticeContract-BasesForAppeal}
 						Bases for appeal are limited to: (1) violation of academic freedom, (2) discrimination as defined in the college's policy on unlawful discrimination and harassment, and (3) failure by the College to abide by institutional policies stated in the \emph{Faculty Handbook}.}
-					\item{The faculty member may choose to confer with others, not including members of the Faculty Council, in marshalling evidence and writing the appeal.}
+					\item{The faculty member may choose to confer with others, not including members of the Faculty Council, in marshaling evidence and writing the appeal.}
 					\item{If the Faculty Council is convinced that a \underline{prima facie} case has been established
 						\begin{enumerate}[label=\arabic*)]
 							\item{Faculty Council will investigate the merits of the appeal


### PR DESCRIPTION
Replaced “marshalling” with “marshaling”. Non-substantive change approved by Kim.